### PR TITLE
Fix: 6_local_Test_Code

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # .env
-# REACT_APP_API_URL=http://localhost:5000
+ REACT_APP_API_URL=http://localhost:5000
 
 # .env.production
-REACT_APP_API_URL=https://port-0-node-lyzuq35q9d13710b.sel4.cloudtype.app
+# REACT_APP_API_URL=https://port-0-node-lyzuq35q9d13710b.sel4.cloudtype.app
 
 # `${process.env.REACT_APP_API_URL}/api/stickys`


### PR DESCRIPTION
Fix: 6_local_Test_Code
FrontEnd 파일에 보면 .env 환경 변수 파일이 있는데 배포 전에는 localhost 주소를 주석을 해제하고 사용하고 배포 전에 localhost를 주석하고 사이트 주소를 주석 해제하고 빌드 하면 됩니다.